### PR TITLE
Improve quiz cache management in useUpdateQuestion for better UX

### DIFF
--- a/hooks/instructor/useQuizInstructor.ts
+++ b/hooks/instructor/useQuizInstructor.ts
@@ -115,11 +115,14 @@ export function useUpdateQuestion() {
         },
         onSuccess: ({ quizId, question }) => {
             // Update the quiz cache with the updated question
+            queryClient.invalidateQueries({ queryKey: QUIZ_KEYS.quiz(quizId) });
+
+            // Update the quiz cache immediately for a responsive UX
             queryClient.setQueryData<QuizDto | undefined>(
                 QUIZ_KEYS.quiz(quizId),
                 (oldData) => {
                     if (!oldData) {
-                      return undefined;
+                        return undefined;
                     }
 
                     return {


### PR DESCRIPTION
This pull request updates the `useUpdateQuestion` hook in `hooks/instructor/useQuizInstructor.ts` to improve the user experience when updating quiz questions. The primary change ensures that the quiz cache is invalidated and updated immediately for a more responsive interface.

### Improvements to quiz cache handling:

* [`hooks/instructor/useQuizInstructor.ts`](diffhunk://#diff-fbe780262a2156eb319964dee4e2d5a6e98b6ea64a3d86670c95d1872feecff0R118-R120): Added a call to `queryClient.invalidateQueries` to invalidate the quiz cache after a question update and ensure the data is refreshed. This is followed by an immediate update to the quiz cache using `queryClient.setQueryData` for better responsiveness.

## Summary by Sourcery

Enhancements:
- Implement immediate cache invalidation and update for quiz questions to provide more responsive UI